### PR TITLE
Fixed to add proxy check content.

### DIFF
--- a/pages/ip_report.js
+++ b/pages/ip_report.js
@@ -68,22 +68,21 @@ function replace_html(selectedText, resPro, resSho, resAbu, resRev) {
     else {
       replaceText += strNoOpenPorts;
     }
+  }
+  replaceText += '</div>';
 
-    replaceText += '</div>';
+  // Proxy check
+  replaceText += '<h2>' + strProxyCheck + '</h2>';
+  replaceText += '<div style="margin-left: 20px">';
 
-    // Proxy check
-    replaceText += '<h2>' + strProxyCheck + '</h2>';
-    replaceText += '<div style="margin-left: 20px">';
+  if (resPro.status != 'ok') {
+    replaceText += strDataFetchFailed
+  }
+  else {
+    replaceText += strProxy + ': ' + resPro[selectedText].proxy;
 
-    if (resPro.status != 'ok') {
-      replaceText += strDataFetchFailed
-    }
-    else {
-      replaceText += strProxy + ': ' + resPro[selectedText].proxy;
-
-      if (resPro[selectedText].proxy == 'yes')
-        replaceText += ' , ' + strType + ': ' + resPro[selectedText].type
-    }
+    if (resPro[selectedText].proxy == 'yes')
+      replaceText += ' , ' + strType + ': ' + resPro[selectedText].type
   }
   replaceText += '</div>';
 


### PR DESCRIPTION
When IP report creation function is launch, the proxy check contents have been ignored if the Shodan's response was 0.
Its fixed.